### PR TITLE
Minimal Code Changes to Support Latest PyTorch and Bug Fixed for Extremely Low Adaptation Accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 A PyTorch implementation for [Adversarial Discriminative Domain Adaptation](https://arxiv.org/abs/1702.05464).
 
 ## Environment
-- Python 3.6
-- PyTorch 0.2.0
+- Python >= 3.6 (Tested on Python 3.8)
+- PyTorch >= 1.0.0 (Tested on PyTorch 1.11.0)
 
 ## Usage
 

--- a/core/adapt.py
+++ b/core/adapt.py
@@ -107,9 +107,9 @@ def train_tgt(src_encoder, tgt_encoder, critic,
                               params.num_epochs,
                               step + 1,
                               len_data_loader,
-                              loss_critic.data[0],
-                              loss_tgt.data[0],
-                              acc.data[0]))
+                              loss_critic.item(),
+                              loss_tgt.item(),
+                              acc.item()))
 
         #############################
         # 2.4 save model parameters #

--- a/core/pretrain.py
+++ b/core/pretrain.py
@@ -52,7 +52,7 @@ def train_src(encoder, classifier, data_loader):
                               params.num_epochs_pre,
                               step + 1,
                               len(data_loader),
-                              loss.data[0]))
+                              loss.item()))
 
         # eval model on test set
         if ((epoch + 1) % params.eval_step_pre == 0):
@@ -78,8 +78,8 @@ def eval_src(encoder, classifier, data_loader):
     classifier.eval()
 
     # init loss and accuracy
-    loss = 0
-    acc = 0
+    loss = 0.
+    acc = 0.
 
     # set loss function
     criterion = nn.CrossEntropyLoss()
@@ -90,7 +90,7 @@ def eval_src(encoder, classifier, data_loader):
         labels = make_variable(labels)
 
         preds = classifier(encoder(images))
-        loss += criterion(preds, labels).data[0]
+        loss += criterion(preds, labels).item()
 
         pred_cls = preds.data.max(1)[1]
         acc += pred_cls.eq(labels.data).cpu().sum()

--- a/core/test.py
+++ b/core/test.py
@@ -13,8 +13,8 @@ def eval_tgt(encoder, classifier, data_loader):
     classifier.eval()
 
     # init loss and accuracy
-    loss = 0
-    acc = 0
+    loss = 0.
+    acc = 0.
 
     # set loss function
     criterion = nn.CrossEntropyLoss()
@@ -25,7 +25,7 @@ def eval_tgt(encoder, classifier, data_loader):
         labels = make_variable(labels).squeeze_()
 
         preds = classifier(encoder(images))
-        loss += criterion(preds, labels).data[0]
+        loss += criterion(preds, labels).item()
 
         pred_cls = preds.data.max(1)[1]
         acc += pred_cls.eq(labels.data).cpu().sum()

--- a/datasets/usps.py
+++ b/datasets/usps.py
@@ -57,7 +57,7 @@ class USPS(data.Dataset):
             np.random.shuffle(indices)
             self.train_data = self.train_data[indices[0:self.dataset_size], ::]
             self.train_labels = self.train_labels[indices[0:self.dataset_size]]
-        self.train_data *= 255.0
+
         self.train_data = self.train_data.transpose(
             (0, 2, 3, 1))  # convert to HWC
 

--- a/models/discriminator.py
+++ b/models/discriminator.py
@@ -18,7 +18,6 @@ class Discriminator(nn.Module):
             nn.Linear(hidden_dims, hidden_dims),
             nn.ReLU(),
             nn.Linear(hidden_dims, output_dims),
-            nn.LogSoftmax()
         )
 
     def forward(self, input):

--- a/params.py
+++ b/params.py
@@ -4,8 +4,8 @@
 data_root = "data"
 dataset_mean_value = 0.5
 dataset_std_value = 0.5
-dataset_mean = (dataset_mean_value, dataset_mean_value, dataset_mean_value)
-dataset_std = (dataset_std_value, dataset_std_value, dataset_std_value)
+dataset_mean = dataset_mean_value
+dataset_std = dataset_std_value
 batch_size = 50
 image_size = 64
 

--- a/utils.py
+++ b/utils.py
@@ -15,7 +15,7 @@ def make_variable(tensor, volatile=False):
     """Convert Tensor to Variable."""
     if torch.cuda.is_available():
         tensor = tensor.cuda()
-    return Variable(tensor, volatile=volatile)
+    return tensor
 
 
 def make_cuda(tensor):


### PR DESCRIPTION
Thanks for contributing this repo, which is really nice to learn domain adaptation. 

1. Just made some minimal code changes to support latest PyTorch (>= 1.0) and Python (>= 3.6) (https://github.com/corenel/pytorch-adda/pull/29/commits/0f98f5de673d0842f484a6460f2367131c243aad).  

2. Fixed the low adaptation accuracy (10%-15%) mentioned in #27 #26 #22 #15 #10 #8 #7 #1. The bug is due to the different normalization applied to MNIST and USPS. The data loader normalizes all the MNIST images to 0-1, while normalizing all the USPS images to 0-255. Changing the latter to 0-1 leads to normal performance (https://github.com/corenel/pytorch-adda/pull/29/commits/13a295ab5c94a572854cdf0ffa5e63c65e209777):


```
=== Evaluating classifier for source domain === (100 epochs)
Avg Loss = 0.08870776686510162, Avg Accuracy = 99.250001%

=== Evaluating classifier for encoded target domain === (100 epochs)
>>> source only <<<
Avg Loss = 0.6725219937139436, Avg Accuracy = 87.956989%
>>> domain adaption <<<
Avg Loss = 0.49638841790887883, Avg Accuracy = 97.365594%
```

3. Fixed the outputs of the discriminator mentioned in #16 #11 #2. For nn.CrossEntropyLoss, the input is expected to contain raw, unnormalized scores for each class, rather than logprobs (https://github.com/corenel/pytorch-adda/pull/29/commits/6e59bbddfe1e254ab8eade18d6b5b489db099e52). However, the performance is not improved after correction.

```
=== Evaluating classifier for encoded target domain === (100 epochs)
>>> source only <<<
Avg Loss = 0.6533445982556594, Avg Accuracy = 87.956989%
>>> domain adaption <<<
Avg Loss = 0.46242921638726453, Avg Accuracy = 97.204304%
```